### PR TITLE
[#16] 음원 게시물 관련 기능 페이징 처리 및 구체화

### DIFF
--- a/module-api/src/main/java/com/soundie/api/CommentController.java
+++ b/module-api/src/main/java/com/soundie/api/CommentController.java
@@ -1,8 +1,6 @@
 package com.soundie.api;
 
-import com.soundie.comment.dto.CommentIdElement;
-import com.soundie.comment.dto.GetCommentResDto;
-import com.soundie.comment.dto.PostCommentCreateReqDto;
+import com.soundie.comment.dto.*;
 import com.soundie.comment.service.CommentService;
 import com.soundie.global.common.dto.EnvelopeResponse;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +18,15 @@ public class CommentController {
                                                            @RequestParam(required = false) Long memberId){
         return EnvelopeResponse.<GetCommentResDto>builder()
                 .data(commentService.readCommentList(postId))
+                .build();
+    }
+
+    @GetMapping("/cursor")
+    public EnvelopeResponse<GetCommentCursorResDto> readCommentsByCursor(@RequestBody GetCommentCursorReqDto getCommentCursorReqDto,
+                                                                         @RequestParam Long postId,
+                                                                         @RequestParam(required = false) Long memberId){
+        return EnvelopeResponse.<GetCommentCursorResDto>builder()
+                .data(commentService.readCommentListByCursor(postId, getCommentCursorReqDto))
                 .build();
     }
 

--- a/module-api/src/main/java/com/soundie/api/PostController.java
+++ b/module-api/src/main/java/com/soundie/api/PostController.java
@@ -22,7 +22,7 @@ public class PostController {
 
     @GetMapping("/cursor")
     public EnvelopeResponse<GetPostCursorResDto> readPostsByCursor(@RequestBody GetPostCursorReqDto getPostCursorReqDto,
-                                                                      @RequestParam(required = false) Long memberId) {
+                                                                   @RequestParam(required = false) Long memberId) {
         return EnvelopeResponse.<GetPostCursorResDto>builder()
                 .data(postService.readPostListByCursor(getPostCursorReqDto))
                 .build();

--- a/module-api/src/main/java/com/soundie/api/PostController.java
+++ b/module-api/src/main/java/com/soundie/api/PostController.java
@@ -14,14 +14,14 @@ public class PostController {
     private final PostService postService;
 
     @GetMapping
-    public EnvelopeResponse<GetPostResDto> readPostList(@RequestParam(required = false) Long memberId){
+    public EnvelopeResponse<GetPostResDto> readPosts(@RequestParam(required = false) Long memberId){
         return EnvelopeResponse.<GetPostResDto>builder()
                 .data(postService.readPostList())
                 .build();
     }
 
     @GetMapping("/cursor")
-    public EnvelopeResponse<GetPostCursorResDto> readPostListByCursor(@RequestBody GetPostCursorReqDto getPostCursorReqDto,
+    public EnvelopeResponse<GetPostCursorResDto> readPostsByCursor(@RequestBody GetPostCursorReqDto getPostCursorReqDto,
                                                                       @RequestParam(required = false) Long memberId) {
         return EnvelopeResponse.<GetPostCursorResDto>builder()
                 .data(postService.readPostListByCursor(getPostCursorReqDto))

--- a/module-api/src/main/java/com/soundie/api/PostController.java
+++ b/module-api/src/main/java/com/soundie/api/PostController.java
@@ -20,6 +20,14 @@ public class PostController {
                 .build();
     }
 
+    @GetMapping("/cursor")
+    public EnvelopeResponse<GetPostCursorResDto> readPostListByCursor(@RequestBody GetPostCursorReqDto getPostCursorReqDto,
+                                                                      @RequestParam(required = false) Long memberId) {
+        return EnvelopeResponse.<GetPostCursorResDto>builder()
+                .data(postService.readPostListByCursor(getPostCursorReqDto))
+                .build();
+    }
+
     @GetMapping("/{postId}")
     public EnvelopeResponse<GetPostDetailResDto> readPost(@PathVariable Long postId,
                                                           @RequestParam(required = false) Long memberId){

--- a/module-core/src/main/java/com/soundie/comment/dto/GetCommentCursorReqDto.java
+++ b/module-core/src/main/java/com/soundie/comment/dto/GetCommentCursorReqDto.java
@@ -1,0 +1,18 @@
+package com.soundie.comment.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetCommentCursorReqDto {
+
+    private Long cursor;
+    private Integer size = 10;
+
+    public GetCommentCursorReqDto(Long cursor, Integer size){
+        this.cursor = cursor;
+        this.size = size;
+    }
+}

--- a/module-core/src/main/java/com/soundie/comment/dto/GetCommentCursorReqDto.java
+++ b/module-core/src/main/java/com/soundie/comment/dto/GetCommentCursorReqDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetCommentCursorReqDto {
 
-    private Long cursor;
+    private Long cursor = -1L;
     private Integer size = 10;
 
     public GetCommentCursorReqDto(Long cursor, Integer size){

--- a/module-core/src/main/java/com/soundie/comment/dto/GetCommentCursorResDto.java
+++ b/module-core/src/main/java/com/soundie/comment/dto/GetCommentCursorResDto.java
@@ -1,0 +1,48 @@
+package com.soundie.comment.dto;
+
+import com.soundie.comment.domain.Comment;
+import com.soundie.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder(builderMethodName = "innerBuilder")
+public class GetCommentCursorResDto {
+
+    private final Collection<GetCommentElement> comments;
+    private final Long cursor;
+
+    private static GetCommentCursorResDtoBuilder builder(Collection<GetCommentElement> comments,
+                                                         Long cursor) {
+        return innerBuilder()
+                .comments(comments)
+                .cursor(cursor);
+    }
+
+    public static GetCommentCursorResDto of(List<Comment> comments, Map<Long, Member> linkedHashMap, Integer size) {
+        return GetCommentCursorResDto.builder(
+                        comments.stream()
+                                .map(c -> {
+                                    Member member = linkedHashMap.get(c.getId());
+                                    return GetCommentElement.of(c, member);
+                                })
+                                .collect(Collectors.toList()),
+                        getNextCursor(comments, size)
+                )
+                .build();
+    }
+
+    private static Long getNextCursor(List<Comment> comments, Integer size) {
+        Long nextCursor = null;
+        if (comments.size() == size) {
+            nextCursor = comments.get(size - 1).getId();
+        }
+
+        return nextCursor;
+    }
+}

--- a/module-core/src/main/java/com/soundie/comment/mapper/CommentMapper.java
+++ b/module-core/src/main/java/com/soundie/comment/mapper/CommentMapper.java
@@ -13,6 +13,15 @@ public interface CommentMapper {
 
     List<Comment> findCommentsByPostId(@Param("postId") Long postId);
 
+    List<Comment> findCommentsByPostIdOrderByIdAscCreatedAtAsc(
+            @Param("postId") Long postId,
+            @Param("size") Integer size);
+
+    List<Comment> findCommentsByPostIdAndIdLessThanOrderByIdAscCreatedAtAsc(
+            @Param("postId") Long postId,
+            @Param("id") Long commentId,
+            @Param("size") Integer size);
+
     Long countCommentsByPostId(@Param("postId") Long postId);
 
     void save(@Param("comment") Comment comment);

--- a/module-core/src/main/java/com/soundie/comment/repository/CommentRepository.java
+++ b/module-core/src/main/java/com/soundie/comment/repository/CommentRepository.java
@@ -10,6 +10,10 @@ public interface CommentRepository {
 
     List<Comment> findCommentsByPostId(Long postId);
 
+    List<Comment> findCommentsByPostIdOrderByIdAscCreatedAtAsc(Long postId, Integer size);
+
+    List<Comment> findCommentsByPostIdAndIdLessThanOrderByIdAscCreatedAtAsc(Long postId, Long cursor, Integer size);
+
     Long countCommentsByPostId(Long postId);
 
     Comment save(Comment comment);

--- a/module-core/src/main/java/com/soundie/comment/repository/MemoryCommentRepository.java
+++ b/module-core/src/main/java/com/soundie/comment/repository/MemoryCommentRepository.java
@@ -33,6 +33,18 @@ public class MemoryCommentRepository implements CommentRepository {
                 .collect(Collectors.toList());
     }
 
+    @Override
+    public List<Comment> findCommentsByPostIdOrderByIdAscCreatedAtAsc(Long postId, Integer size) {
+        // 구현 필요
+        return null;
+    }
+
+    @Override
+    public List<Comment> findCommentsByPostIdAndIdLessThanOrderByIdAscCreatedAtAsc(Long postId, Long cursor, Integer size) {
+        // 구현 필요
+        return null;
+    }
+
     /*
     * 음원 게시물 Id로, 댓글 개수 조회
     * */

--- a/module-core/src/main/java/com/soundie/comment/repository/MyBatisCommentRepository.java
+++ b/module-core/src/main/java/com/soundie/comment/repository/MyBatisCommentRepository.java
@@ -29,6 +29,16 @@ public class MyBatisCommentRepository implements CommentRepository {
         return commentMapper.findCommentsByPostId(postId);
     }
 
+    @Override
+    public List<Comment> findCommentsByPostIdOrderByIdAscCreatedAtAsc(Long postId, Integer size) {
+        return commentMapper.findCommentsByPostIdOrderByIdAscCreatedAtAsc(postId, size);
+    }
+
+    @Override
+    public List<Comment> findCommentsByPostIdAndIdLessThanOrderByIdAscCreatedAtAsc(Long postId, Long cursor, Integer size) {
+        return commentMapper.findCommentsByPostIdAndIdLessThanOrderByIdAscCreatedAtAsc(postId, cursor, size);
+    }
+
     /*
      * 음원 게시물 Id로, 댓글 개수 조회
      * */

--- a/module-core/src/main/java/com/soundie/comment/service/CommentService.java
+++ b/module-core/src/main/java/com/soundie/comment/service/CommentService.java
@@ -63,7 +63,7 @@ public class CommentService {
     }
 
     private List<Comment> findCommentsByCursorCheckExistsCursor(Long postId, Long cursor, Integer size) {
-        return cursor == null ? commentRepository.findCommentsByPostIdOrderByIdAscCreatedAtAsc(postId, size)
+        return cursor.equals(-1L) ? commentRepository.findCommentsByPostIdOrderByIdAscCreatedAtAsc(postId, size)
                 : commentRepository.findCommentsByPostIdAndIdLessThanOrderByIdAscCreatedAtAsc(postId, cursor, size);
     }
 

--- a/module-core/src/main/java/com/soundie/post/dto/GetPostCursorReqDto.java
+++ b/module-core/src/main/java/com/soundie/post/dto/GetPostCursorReqDto.java
@@ -1,0 +1,18 @@
+package com.soundie.post.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetPostCursorReqDto {
+
+    private Long cursor;
+    private Integer size = 5;
+
+    public GetPostCursorReqDto(Long cursor, Integer size){
+        this.cursor = cursor;
+        this.size = size;
+    }
+}

--- a/module-core/src/main/java/com/soundie/post/dto/GetPostCursorReqDto.java
+++ b/module-core/src/main/java/com/soundie/post/dto/GetPostCursorReqDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetPostCursorReqDto {
 
-    private Long cursor;
+    private Long cursor = -1L;
     private Integer size = 5;
 
     public GetPostCursorReqDto(Long cursor, Integer size){

--- a/module-core/src/main/java/com/soundie/post/dto/GetPostCursorResDto.java
+++ b/module-core/src/main/java/com/soundie/post/dto/GetPostCursorResDto.java
@@ -1,0 +1,43 @@
+package com.soundie.post.dto;
+
+import com.soundie.post.domain.PostWithCount;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder(builderMethodName = "innerBuilder")
+public class GetPostCursorResDto {
+
+    private final Collection<GetPostElement> posts;
+    private final Long cursor;
+
+    private static GetPostCursorResDtoBuilder builder(Collection<GetPostElement> posts,
+                                                      Long cursor){
+        return innerBuilder()
+                .posts(posts)
+                .cursor(cursor);
+    }
+
+    public static GetPostCursorResDto of(List<PostWithCount> postsWithCount, Integer size) {
+        return GetPostCursorResDto.builder(
+                        postsWithCount.stream()
+                                .map(GetPostElement::of)
+                                .collect(Collectors.toList()),
+                        getNextCursor(postsWithCount, size)
+                )
+                .build();
+    }
+
+    private static Long getNextCursor(List<PostWithCount> postsWithCount, Integer size) {
+        Long nextCursor = null;
+        if (postsWithCount.size() == size) {
+            nextCursor = postsWithCount.get(size - 1).getId();
+        }
+
+        return nextCursor;
+    }
+}

--- a/module-core/src/main/java/com/soundie/post/mapper/PostMapper.java
+++ b/module-core/src/main/java/com/soundie/post/mapper/PostMapper.java
@@ -12,6 +12,11 @@ public interface PostMapper {
 
     List<Post> findPosts();
 
+    List<Post> findPostsByOrderByIdDescCreatedAtDesc(Integer size);
+
+    List<Post> findPostsByIdLessThanOrderByIdDescCreatedAtDesc(@Param("id") Long postId,
+                                                               Integer size);
+
     Optional<Post> findPostById(@Param("id") Long postId);
 
     void save(@Param("post") Post post);

--- a/module-core/src/main/java/com/soundie/post/mapper/PostMapper.java
+++ b/module-core/src/main/java/com/soundie/post/mapper/PostMapper.java
@@ -12,10 +12,11 @@ public interface PostMapper {
 
     List<Post> findPosts();
 
-    List<Post> findPostsByOrderByIdDescCreatedAtDesc(Integer size);
+    List<Post> findPostsByOrderByIdDescCreatedAtDesc(@Param("size") Integer size);
 
-    List<Post> findPostsByIdLessThanOrderByIdDescCreatedAtDesc(@Param("id") Long postId,
-                                                               Integer size);
+    List<Post> findPostsByIdLessThanOrderByIdDescCreatedAtDesc(
+            @Param("id") Long postId,
+            @Param("size") Integer size);
 
     Optional<Post> findPostById(@Param("id") Long postId);
 

--- a/module-core/src/main/java/com/soundie/post/repository/MemoryPostRepository.java
+++ b/module-core/src/main/java/com/soundie/post/repository/MemoryPostRepository.java
@@ -22,6 +22,19 @@ public class MemoryPostRepository implements PostRepository {
         return new ArrayList<>(store.values());
     }
 
+    
+    @Override
+    public List<Post> findPostsByOrderByIdDescCreatedAtDesc(Integer size) {
+        // 구현 필요
+        return null;
+    }
+
+    @Override
+    public List<Post> findPostsByIdLessThanOrderByIdDescCreatedAtDesc(Long postId, Integer size) {
+        // 구현 필요
+        return null;
+    }
+
     /*
      * 음원 게시물 Id로, 음원 게시물 조회
      * */

--- a/module-core/src/main/java/com/soundie/post/repository/MyBatisPostRepository.java
+++ b/module-core/src/main/java/com/soundie/post/repository/MyBatisPostRepository.java
@@ -22,6 +22,16 @@ public class MyBatisPostRepository implements PostRepository {
         return postMapper.findPosts();
     }
 
+    @Override
+    public List<Post> findPostsByOrderByIdDescCreatedAtDesc(Integer size) {
+        return postMapper.findPostsByOrderByIdDescCreatedAtDesc(size);
+    }
+
+    @Override
+    public List<Post> findPostsByIdLessThanOrderByIdDescCreatedAtDesc(Long postId, Integer size) {
+        return postMapper.findPostsByIdLessThanOrderByIdDescCreatedAtDesc(postId, size);
+    }
+
     /*
      * 음원 게시물 Id로, 음원 게시물 조회
      * */

--- a/module-core/src/main/java/com/soundie/post/repository/PostRepository.java
+++ b/module-core/src/main/java/com/soundie/post/repository/PostRepository.java
@@ -9,6 +9,10 @@ public interface PostRepository {
 
     List<Post> findPosts();
 
+    List<Post> findPostsByOrderByIdDescCreatedAtDesc(Integer size);
+
+    List<Post> findPostsByIdLessThanOrderByIdDescCreatedAtDesc(Long postId, Integer size);
+
     Optional<Post> findPostById(Long postId);
 
     Post save(Post post);

--- a/module-core/src/main/java/com/soundie/post/service/PostService.java
+++ b/module-core/src/main/java/com/soundie/post/service/PostService.java
@@ -78,7 +78,7 @@ public class PostService {
     }
 
     private List<Post> findPostsByCursorCheckExistsCursor(Long cursor, Integer size) {
-        return cursor == null ? postRepository.findPostsByOrderByIdDescCreatedAtDesc(size)
+        return cursor.equals(-1L) ? postRepository.findPostsByOrderByIdDescCreatedAtDesc(size)
                 : postRepository.findPostsByIdLessThanOrderByIdDescCreatedAtDesc(cursor, size);
     }
 

--- a/module-core/src/main/resources/mybatis/mapper/CommentMapper.xml
+++ b/module-core/src/main/resources/mybatis/mapper/CommentMapper.xml
@@ -25,6 +25,35 @@
         where post_id = #{postId}
     </select>
 
+    <select id="findCommentsByPostIdOrderByIdAscCreatedAtAsc"
+            resultType="com.soundie.comment.domain.Comment">
+        select
+            id as "id",
+            member_id as "memberId",
+            post_id as "postId",
+            content as "content",
+            created_at as "createdAt"
+        from comment
+        where post_id = #{postId}
+        order by id asc, created_at asc
+        limit #{size}
+    </select>
+
+    <select id="findCommentsByPostIdAndIdLessThanOrderByIdAscCreatedAtAsc"
+            resultType="com.soundie.comment.domain.Comment">
+        select
+            id as "id",
+            member_id as "memberId",
+            post_id as "postId",
+            content as "content",
+            created_at as "createdAt"
+        from comment
+        where post_id = #{postId}
+            and id &gt; #{id}
+        order by id asc, created_at asc
+        limit #{size}
+    </select>
+
     <!-- 음원 게시물 Id로, 댓글 개수 조회 -->
     <select id="countCommentsByPostId" resultType="Long">
         select count(*)

--- a/module-core/src/main/resources/mybatis/mapper/PostMapper.xml
+++ b/module-core/src/main/resources/mybatis/mapper/PostMapper.xml
@@ -16,6 +16,39 @@
         from post
     </select>
 
+    <select id="findPostsByOrderByIdDescCreatedAtDesc"
+            resultType="com.soundie.post.domain.Post">
+        select
+            id as "id",
+            member_id as "memberId",
+            title as "title",
+            artist_name as "artistName",
+            music_path as "musicPath",
+            album_img_path as "albumImgPath",
+            album_name as "albumName",
+            created_at as "createdAt"
+        from post
+        order by id desc, created_at desc
+        limit #{size}
+    </select>
+
+    <select id="findPostsByIdLessThanOrderByIdDescCreatedAtDesc"
+            resultType="com.soundie.post.domain.Post">
+        select
+            id as "id",
+            member_id as "memberId",
+            title as "title",
+            artist_name as "artistName",
+            music_path as "musicPath",
+            album_img_path as "albumImgPath",
+            album_name as "albumName",
+            created_at as "createdAt"
+        from post
+        where id &lt; #{id}
+        order by id desc, created_at desc
+        limit #{size}
+    </select>
+
     <!-- 음원 게시물 Id로, 음원 게시물 조회 -->
     <select id="findPostById" resultType="com.soundie.post.domain.Post">
         select

--- a/module-core/src/main/resources/sql/schema.sql
+++ b/module-core/src/main/resources/sql/schema.sql
@@ -23,6 +23,8 @@ create table post
 		    on delete cascade
 		    on update cascade
 );
+create index idx_created_at on post(created_at) ;
+create index idx_id on post(id) ;
 
 drop table if exists comment CASCADE;
 create table comment

--- a/module-core/src/main/resources/sql/schema.sql
+++ b/module-core/src/main/resources/sql/schema.sql
@@ -42,6 +42,8 @@ create table comment
 		    on delete cascade
 		    on update cascade
 );
+create index comment_idx_created_at on comment(created_at);
+create index comment_idx_id on comment(id);
 
 drop table if exists postlike CASCADE;
 create table postlike

--- a/module-core/src/main/resources/sql/schema.sql
+++ b/module-core/src/main/resources/sql/schema.sql
@@ -23,8 +23,8 @@ create table post
 		    on delete cascade
 		    on update cascade
 );
-create index idx_created_at on post(created_at) ;
-create index idx_id on post(id) ;
+create index post_idx_created_at on post(created_at);
+create index post_idx_id on post(id);
 
 drop table if exists comment CASCADE;
 create table comment


### PR DESCRIPTION
## Description
- 음원 게시물 목록 조회 기능
- 음원 게시물 상세 조회 기능
- 음원 게시물 댓글 목록 조회 기능

## Todo
- 음원 게시물 목록 조회 기능
   - 음원 게시물 목록 조회는 로그인하지 않아도 조회가 가능하다.
   - 음원 게시물 목록 조회는 좋아요 수와 댓글 수가 조회가 필요하다.
   - 음원 게시물 목록 조회는 앨범 이미지 조회가 가능하다.
   - 음원 게시물 목록 조회는 페이지 처리로 조회가 가능하다.
     - 페이징으로 조회 시, 최근 등록 시간으로 페이징을 한다.
     - 페이징으로 조회 시, 5개씩 조회하도록 한다.
- 음원 게시물 상세 조회
  - 음원 게시물 상세 조회는 로그인하지 않아도 조회가 가능하다.
  - 음원 게시물 상세 조회는 좋아요 수와 댓글 수가 조회가 필요하다.
  - 음원 게시물 상세 조회는 앨범 이미지 조회가 가능하다.
  - 음원 게시물 상세 조회는 음악 재생이 가능하다.
  - 음원 게시물 상세 조회는 달린 댓글들 조회가 가능하다.
    - 페이징으로 조회 시, 과거 등록 시간으로 페이징을 한다.
    - 페이징으로 조회 시, 10개씩 조회하도록 한다.
  - 음원 게시물 상세 조회는 로그인하지 않으면 좋아요 여부가 False다
  - 음원 게시물 상세 조회는 로그인하면 좋아요 여부가 False일수도 True일 수도 있다.
