### PR TITLE
[#22] 요청 dto 불필요한 생성자 제거

### DIFF
--- a/module-core/src/main/java/com/soundie/chatMessage/dto/GetChatMessageCursorReqDto.java
+++ b/module-core/src/main/java/com/soundie/chatMessage/dto/GetChatMessageCursorReqDto.java
@@ -11,9 +11,4 @@ public class GetChatMessageCursorReqDto {
 
     private Long cursor = PaginationUtil.START_CURSOR;
     private Integer size = PaginationUtil.CHAT_MESSAGE_SIZE;
-
-    public GetChatMessageCursorReqDto(Long cursor, Integer size){
-        this.cursor = cursor;
-        this.size = size;
-    }
 }

--- a/module-core/src/main/java/com/soundie/chatMessage/dto/PostChatMessageCreateReqDto.java
+++ b/module-core/src/main/java/com/soundie/chatMessage/dto/PostChatMessageCreateReqDto.java
@@ -10,9 +10,4 @@ public class PostChatMessageCreateReqDto {
 
     private String content; // 메시지 내용
     private int memberCnt; // 채팅방에 접속한 인원
-
-    public PostChatMessageCreateReqDto(String content, int memberCnt){
-        this.content = content;
-        this.memberCnt = memberCnt;
-    }
 }

--- a/module-core/src/main/java/com/soundie/chatRoom/dto/PostChatRoomCreateReqDto.java
+++ b/module-core/src/main/java/com/soundie/chatRoom/dto/PostChatRoomCreateReqDto.java
@@ -11,10 +11,4 @@ public class PostChatRoomCreateReqDto {
     private Long guestMemberId;
     private String name;
     private String description;
-
-    public PostChatRoomCreateReqDto(Long guestMemberId, String name, String description){
-        this.guestMemberId = guestMemberId;
-        this.name = name;
-        this.description = description;
-    }
 }

--- a/module-core/src/main/java/com/soundie/comment/dto/GetCommentCursorReqDto.java
+++ b/module-core/src/main/java/com/soundie/comment/dto/GetCommentCursorReqDto.java
@@ -11,9 +11,4 @@ public class GetCommentCursorReqDto {
 
     private Long cursor = PaginationUtil.START_CURSOR;
     private Integer size = PaginationUtil.COMMENT_SIZE;
-
-    public GetCommentCursorReqDto(Long cursor, Integer size){
-        this.cursor = cursor;
-        this.size = size;
-    }
 }

--- a/module-core/src/main/java/com/soundie/comment/dto/PostCommentCreateReqDto.java
+++ b/module-core/src/main/java/com/soundie/comment/dto/PostCommentCreateReqDto.java
@@ -9,6 +9,9 @@ import lombok.NoArgsConstructor;
 public class PostCommentCreateReqDto {
     private String content;
 
+    /*
+    * test 를 위한 생성자
+    * */
     public PostCommentCreateReqDto(String content){
         this.content = content;
     }

--- a/module-core/src/main/java/com/soundie/member/dto/PostMemberCreateReqDto.java
+++ b/module-core/src/main/java/com/soundie/member/dto/PostMemberCreateReqDto.java
@@ -7,9 +7,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostMemberCreateReqDto {
-    private String name;
 
-    public PostMemberCreateReqDto(String name){
-        this.name = name;
-    }
+    private String name;
 }

--- a/module-core/src/main/java/com/soundie/post/dto/GetPostCursorReqDto.java
+++ b/module-core/src/main/java/com/soundie/post/dto/GetPostCursorReqDto.java
@@ -11,9 +11,4 @@ public class GetPostCursorReqDto {
 
     private Long cursor = PaginationUtil.START_CURSOR;
     private Integer size = PaginationUtil.POST_SIZE;
-
-    public GetPostCursorReqDto(Long cursor, Integer size){
-        this.cursor = cursor;
-        this.size = size;
-    }
 }

--- a/module-core/src/main/java/com/soundie/post/dto/PostPostCreateReqDto.java
+++ b/module-core/src/main/java/com/soundie/post/dto/PostPostCreateReqDto.java
@@ -7,11 +7,15 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostPostCreateReqDto {
+
     private String title;
     private String musicPath;
     private String albumImgPath;
     private String albumName;
 
+    /*
+     * test 를 위한 생성자
+     * */
     public PostPostCreateReqDto(String title, String musicPath, String albumImgPath, String albumName){
         this.title = title;
         this.musicPath = musicPath;


### PR DESCRIPTION
## Description
- 요청 dto 불필요한 생성자 제거

## Todo
- @RequestBody의 바인딩은 Jackson라이브러리의 ObjectMapper가 진행
  - ObjectMapper는, @RequestBody가 Property로 구현되어 있거나 생성을 위임한 경우가 아니라면, 기본 생성자로 생성
  - ObjectMapper는, reflection을 사용해서 필드 값들을 넣어줌
