### PR TITLE
[#30] Cursor Pagination 관련 불필요한 index(created_at) 제거

### DIFF
--- a/module-core/src/main/java/com/soundie/comment/mapper/CommentMapper.java
+++ b/module-core/src/main/java/com/soundie/comment/mapper/CommentMapper.java
@@ -13,11 +13,11 @@ public interface CommentMapper {
 
     List<Comment> findCommentsByPostId(@Param("postId") Long postId);
 
-    List<Comment> findCommentsByPostIdOrderByIdAscCreatedAtAsc(
+    List<Comment> findCommentsByPostIdOrderByIdAsc(
             @Param("postId") Long postId,
             @Param("size") Integer size);
 
-    List<Comment> findCommentsByPostIdAndIdLessThanOrderByIdAscCreatedAtAsc(
+    List<Comment> findCommentsByPostIdAndIdLessThanOrderByIdAsc(
             @Param("postId") Long postId,
             @Param("id") Long commentId,
             @Param("size") Integer size);

--- a/module-core/src/main/java/com/soundie/comment/repository/CommentRepository.java
+++ b/module-core/src/main/java/com/soundie/comment/repository/CommentRepository.java
@@ -10,9 +10,9 @@ public interface CommentRepository {
 
     List<Comment> findCommentsByPostId(Long postId);
 
-    List<Comment> findCommentsByPostIdOrderByIdAscCreatedAtAsc(Long postId, Integer size);
+    List<Comment> findCommentsByPostIdOrderByIdAsc(Long postId, Integer size);
 
-    List<Comment> findCommentsByPostIdAndIdLessThanOrderByIdAscCreatedAtAsc(Long postId, Long cursor, Integer size);
+    List<Comment> findCommentsByPostIdAndIdLessThanOrderByIdAsc(Long postId, Long cursor, Integer size);
 
     Number countCommentsByPostId(Long postId);
 

--- a/module-core/src/main/java/com/soundie/comment/repository/MemoryCommentRepository.java
+++ b/module-core/src/main/java/com/soundie/comment/repository/MemoryCommentRepository.java
@@ -34,13 +34,13 @@ public class MemoryCommentRepository implements CommentRepository {
     }
 
     @Override
-    public List<Comment> findCommentsByPostIdOrderByIdAscCreatedAtAsc(Long postId, Integer size) {
+    public List<Comment> findCommentsByPostIdOrderByIdAsc(Long postId, Integer size) {
         // 구현 필요
         return null;
     }
 
     @Override
-    public List<Comment> findCommentsByPostIdAndIdLessThanOrderByIdAscCreatedAtAsc(Long postId, Long cursor, Integer size) {
+    public List<Comment> findCommentsByPostIdAndIdLessThanOrderByIdAsc(Long postId, Long cursor, Integer size) {
         // 구현 필요
         return null;
     }

--- a/module-core/src/main/java/com/soundie/comment/repository/MyBatisCommentRepository.java
+++ b/module-core/src/main/java/com/soundie/comment/repository/MyBatisCommentRepository.java
@@ -32,13 +32,13 @@ public class MyBatisCommentRepository implements CommentRepository {
     }
 
     @Override
-    public List<Comment> findCommentsByPostIdOrderByIdAscCreatedAtAsc(Long postId, Integer size) {
-        return commentMapper.findCommentsByPostIdOrderByIdAscCreatedAtAsc(postId, size);
+    public List<Comment> findCommentsByPostIdOrderByIdAsc(Long postId, Integer size) {
+        return commentMapper.findCommentsByPostIdOrderByIdAsc(postId, size);
     }
 
     @Override
-    public List<Comment> findCommentsByPostIdAndIdLessThanOrderByIdAscCreatedAtAsc(Long postId, Long cursor, Integer size) {
-        return commentMapper.findCommentsByPostIdAndIdLessThanOrderByIdAscCreatedAtAsc(postId, cursor, size);
+    public List<Comment> findCommentsByPostIdAndIdLessThanOrderByIdAsc(Long postId, Long cursor, Integer size) {
+        return commentMapper.findCommentsByPostIdAndIdLessThanOrderByIdAsc(postId, cursor, size);
     }
 
     /*

--- a/module-core/src/main/java/com/soundie/comment/service/CommentService.java
+++ b/module-core/src/main/java/com/soundie/comment/service/CommentService.java
@@ -117,8 +117,8 @@ public class CommentService {
     }
 
     private List<Comment> findCommentsByCursorCheckExistsCursor(Long postId, Long cursor, Integer size) {
-        return cursor.equals(PaginationUtil.START_CURSOR) ? commentRepository.findCommentsByPostIdOrderByIdAscCreatedAtAsc(postId, size)
-                : commentRepository.findCommentsByPostIdAndIdLessThanOrderByIdAscCreatedAtAsc(postId, cursor, size);
+        return cursor.equals(PaginationUtil.START_CURSOR) ? commentRepository.findCommentsByPostIdOrderByIdAsc(postId, size)
+                : commentRepository.findCommentsByPostIdAndIdLessThanOrderByIdAsc(postId, cursor, size);
     }
 
     private Map<Long, Member> findCommentsByMember(List<Comment> comments) {

--- a/module-core/src/main/java/com/soundie/post/mapper/PostMapper.java
+++ b/module-core/src/main/java/com/soundie/post/mapper/PostMapper.java
@@ -12,9 +12,9 @@ public interface PostMapper {
 
     List<Post> findPosts();
 
-    List<Post> findPostsByOrderByIdDescCreatedAtDesc(@Param("size") Integer size);
+    List<Post> findPostsOrderByIdDesc(@Param("size") Integer size);
 
-    List<Post> findPostsByIdLessThanOrderByIdDescCreatedAtDesc(
+    List<Post> findPostsByIdLessThanOrderByIdDesc(
             @Param("id") Long postId,
             @Param("size") Integer size);
 

--- a/module-core/src/main/java/com/soundie/post/repository/MemoryPostRepository.java
+++ b/module-core/src/main/java/com/soundie/post/repository/MemoryPostRepository.java
@@ -24,13 +24,13 @@ public class MemoryPostRepository implements PostRepository {
 
     
     @Override
-    public List<Post> findPostsByOrderByIdDescCreatedAtDesc(Integer size) {
+    public List<Post> findPostsOrderByIdDesc(Integer size) {
         // 구현 필요
         return null;
     }
 
     @Override
-    public List<Post> findPostsByIdLessThanOrderByIdDescCreatedAtDesc(Long postId, Integer size) {
+    public List<Post> findPostsByIdLessThanOrderByIdDesc(Long postId, Integer size) {
         // 구현 필요
         return null;
     }

--- a/module-core/src/main/java/com/soundie/post/repository/MyBatisPostRepository.java
+++ b/module-core/src/main/java/com/soundie/post/repository/MyBatisPostRepository.java
@@ -25,13 +25,13 @@ public class MyBatisPostRepository implements PostRepository {
     }
 
     @Override
-    public List<Post> findPostsByOrderByIdDescCreatedAtDesc(Integer size) {
-        return postMapper.findPostsByOrderByIdDescCreatedAtDesc(size);
+    public List<Post> findPostsOrderByIdDesc(Integer size) {
+        return postMapper.findPostsOrderByIdDesc(size);
     }
 
     @Override
-    public List<Post> findPostsByIdLessThanOrderByIdDescCreatedAtDesc(Long postId, Integer size) {
-        return postMapper.findPostsByIdLessThanOrderByIdDescCreatedAtDesc(postId, size);
+    public List<Post> findPostsByIdLessThanOrderByIdDesc(Long postId, Integer size) {
+        return postMapper.findPostsByIdLessThanOrderByIdDesc(postId, size);
     }
 
     /*

--- a/module-core/src/main/java/com/soundie/post/repository/PostRepository.java
+++ b/module-core/src/main/java/com/soundie/post/repository/PostRepository.java
@@ -9,9 +9,9 @@ public interface PostRepository {
 
     List<Post> findPosts();
 
-    List<Post> findPostsByOrderByIdDescCreatedAtDesc(Integer size);
+    List<Post> findPostsOrderByIdDesc(Integer size);
 
-    List<Post> findPostsByIdLessThanOrderByIdDescCreatedAtDesc(Long postId, Integer size);
+    List<Post> findPostsByIdLessThanOrderByIdDesc(Long postId, Integer size);
 
     Optional<Post> findPostById(Long postId);
 

--- a/module-core/src/main/java/com/soundie/post/service/PostService.java
+++ b/module-core/src/main/java/com/soundie/post/service/PostService.java
@@ -162,8 +162,8 @@ public class PostService {
     }
 
     private List<Post> findPostsByCursorCheckExistsCursor(Long cursor, Integer size) {
-        return cursor.equals(PaginationUtil.START_CURSOR) ? postRepository.findPostsByOrderByIdDescCreatedAtDesc(size)
-                : postRepository.findPostsByIdLessThanOrderByIdDescCreatedAtDesc(cursor, size);
+        return cursor.equals(PaginationUtil.START_CURSOR) ? postRepository.findPostsOrderByIdDesc(size)
+                : postRepository.findPostsByIdLessThanOrderByIdDesc(cursor, size);
     }
 
     private List<PostWithCount> findPostsWithCount(List<Post> findPosts) {

--- a/module-core/src/main/resources/mybatis/mapper/CommentMapper.xml
+++ b/module-core/src/main/resources/mybatis/mapper/CommentMapper.xml
@@ -25,7 +25,7 @@
         where post_id = #{postId}
     </select>
 
-    <select id="findCommentsByPostIdOrderByIdAscCreatedAtAsc"
+    <select id="findCommentsByPostIdOrderByIdAsc"
             resultType="com.soundie.comment.domain.Comment">
         select
             id as "id",
@@ -35,11 +35,11 @@
             created_at as "createdAt"
         from comment
         where post_id = #{postId}
-        order by id asc, created_at asc
+        order by id asc
         limit #{size}
     </select>
 
-    <select id="findCommentsByPostIdAndIdLessThanOrderByIdAscCreatedAtAsc"
+    <select id="findCommentsByPostIdAndIdLessThanOrderByIdAsc"
             resultType="com.soundie.comment.domain.Comment">
         select
             id as "id",
@@ -50,7 +50,7 @@
         from comment
         where post_id = #{postId}
             and id &gt; #{id}
-        order by id asc, created_at asc
+        order by id asc
         limit #{size}
     </select>
 

--- a/module-core/src/main/resources/mybatis/mapper/PostMapper.xml
+++ b/module-core/src/main/resources/mybatis/mapper/PostMapper.xml
@@ -16,7 +16,7 @@
         from post
     </select>
 
-    <select id="findPostsByOrderByIdDescCreatedAtDesc"
+    <select id="findPostsOrderByIdDesc"
             resultType="com.soundie.post.domain.Post">
         select
             id as "id",
@@ -28,11 +28,11 @@
             album_name as "albumName",
             created_at as "createdAt"
         from post
-        order by id desc, created_at desc
+        order by id desc
         limit #{size}
     </select>
 
-    <select id="findPostsByIdLessThanOrderByIdDescCreatedAtDesc"
+    <select id="findPostsByIdLessThanOrderByIdDesc"
             resultType="com.soundie.post.domain.Post">
         select
             id as "id",
@@ -45,7 +45,7 @@
             created_at as "createdAt"
         from post
         where id &lt; #{id}
-        order by id desc, created_at desc
+        order by id desc
         limit #{size}
     </select>
 

--- a/module-core/src/main/resources/sql/schema.sql
+++ b/module-core/src/main/resources/sql/schema.sql
@@ -23,7 +23,6 @@ create table post
 		    on delete cascade
 		    on update cascade
 );
-create index post_idx_created_at on post(created_at);
 create index post_idx_id on post(id);
 
 drop table if exists comment CASCADE;
@@ -42,7 +41,6 @@ create table comment
 		    on delete cascade
 		    on update cascade
 );
-create index comment_idx_created_at on comment(created_at);
 create index comment_idx_id on comment(id);
 
 drop table if exists postlike CASCADE;


### PR DESCRIPTION
## Description
- 불필요한 index(created_at) 제거

## Todo
- id가 generated by default as identity이기 때문에, created_at index 제거
- 음원 게시물 목록(Cursor Pagination) 관련 수정
- 음원 게시물의 댓글 목록(Cursor Pagination) 관련 수정