### PR TITLE
[#35] entity 클래스 → vo 클래스로 변경

### DIFF
--- a/module-core/src/main/java/com/soundie/comment/domain/CommentWithAuthor.java
+++ b/module-core/src/main/java/com/soundie/comment/domain/CommentWithAuthor.java
@@ -1,5 +1,9 @@
 package com.soundie.comment.domain;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,5 +19,8 @@ public class CommentWithAuthor {
     private String memberName;
     private Long postId;
     private String content;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime createdAt;
 }

--- a/module-core/src/main/java/com/soundie/comment/domain/CommentWithAuthor.java
+++ b/module-core/src/main/java/com/soundie/comment/domain/CommentWithAuthor.java
@@ -23,4 +23,23 @@ public class CommentWithAuthor {
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime createdAt;
+
+    /*
+     * fixture 생성 위함
+     * */
+    public CommentWithAuthor(
+            Long id,
+            Long memberId,
+            String memberName,
+            Long postId,
+            String content,
+            LocalDateTime createdAt
+    ){
+        this.id = id;
+        this.memberId = memberId;
+        this.memberName = memberName;
+        this.postId = postId;
+        this.content = content;
+        this.createdAt = createdAt;
+    }
 }

--- a/module-core/src/main/java/com/soundie/comment/domain/CommentWithAuthor.java
+++ b/module-core/src/main/java/com/soundie/comment/domain/CommentWithAuthor.java
@@ -1,0 +1,19 @@
+package com.soundie.comment.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentWithAuthor {
+
+    private Long id;
+    private Long memberId;
+    private String memberName;
+    private Long postId;
+    private String content;
+    private LocalDateTime createdAt;
+}

--- a/module-core/src/main/java/com/soundie/comment/dto/GetCommentCursorResDto.java
+++ b/module-core/src/main/java/com/soundie/comment/dto/GetCommentCursorResDto.java
@@ -1,7 +1,6 @@
 package com.soundie.comment.dto;
 
-import com.soundie.comment.domain.Comment;
-import com.soundie.member.domain.Member;
+import com.soundie.comment.domain.CommentWithAuthor;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,7 +8,6 @@ import lombok.Getter;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @Getter
@@ -19,22 +17,19 @@ public class GetCommentCursorResDto {
     private final Collection<GetCommentElement> comments;
     private final Long cursor;
 
-    public static GetCommentCursorResDto of(List<Comment> comments, Map<Long, Member> commentsByMember, Integer size) {
+    public static GetCommentCursorResDto of(List<CommentWithAuthor> commentsWithAuthor, Integer size) {
         return new GetCommentCursorResDto(
-                comments.stream()
-                        .map(c -> {
-                            Member member = commentsByMember.get(c.getId());
-                            return GetCommentElement.of(c, member);
-                        })
+                commentsWithAuthor.stream()
+                        .map(GetCommentElement::of)
                         .collect(Collectors.toList()),
-                getNextCursor(comments, size)
+                getNextCursor(commentsWithAuthor, size)
         );
     }
 
-    private static Long getNextCursor(List<Comment> comments, Integer size) {
+    private static Long getNextCursor(List<CommentWithAuthor> commentsWithAuthor, Integer size) {
         Long nextCursor = null;
-        if (comments.size() == size) {
-            nextCursor = comments.get(size - 1).getId();
+        if (commentsWithAuthor.size() == size) {
+            nextCursor = commentsWithAuthor.get(size - 1).getId();
         }
 
         return nextCursor;

--- a/module-core/src/main/java/com/soundie/comment/dto/GetCommentElement.java
+++ b/module-core/src/main/java/com/soundie/comment/dto/GetCommentElement.java
@@ -1,7 +1,6 @@
 package com.soundie.comment.dto;
 
-import com.soundie.comment.domain.Comment;
-import com.soundie.member.domain.Member;
+import com.soundie.comment.domain.CommentWithAuthor;
 import com.soundie.member.dto.AuthorElement;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -18,12 +17,15 @@ public class GetCommentElement {
     private AuthorElement author;
     private LocalDateTime createdAt;
 
-    public static GetCommentElement of(Comment comment, Member member){
+    public static GetCommentElement of(CommentWithAuthor commentWithAuthor){
         return new GetCommentElement(
-                comment.getId(),
-                comment.getContent(),
-                AuthorElement.of(member),
-                comment.getCreatedAt()
+                commentWithAuthor.getId(),
+                commentWithAuthor.getContent(),
+                AuthorElement.of(
+                        commentWithAuthor.getMemberId(),
+                        commentWithAuthor.getMemberName()
+                ),
+                commentWithAuthor.getCreatedAt()
         );
     }
 }

--- a/module-core/src/main/java/com/soundie/comment/dto/GetCommentResDto.java
+++ b/module-core/src/main/java/com/soundie/comment/dto/GetCommentResDto.java
@@ -1,14 +1,12 @@
 package com.soundie.comment.dto;
 
-import com.soundie.comment.domain.Comment;
-import com.soundie.member.domain.Member;
+import com.soundie.comment.domain.CommentWithAuthor;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @Getter
@@ -17,13 +15,10 @@ public class GetCommentResDto {
 
     private final Collection<GetCommentElement> comments;
 
-    public static GetCommentResDto of(List<Comment> comments, Map<Long, Member> commentsByMember) {
+    public static GetCommentResDto of(List<CommentWithAuthor> commentsWithAuthor) {
         return new GetCommentResDto(
-                comments.stream()
-                        .map(c -> {
-                            Member member = commentsByMember.get(c.getId());
-                            return GetCommentElement.of(c, member);
-                        })
+                commentsWithAuthor.stream()
+                        .map(GetCommentElement::of)
                         .collect(Collectors.toList())
         );
     }

--- a/module-core/src/main/java/com/soundie/comment/mapper/CommentMapper.java
+++ b/module-core/src/main/java/com/soundie/comment/mapper/CommentMapper.java
@@ -1,6 +1,7 @@
 package com.soundie.comment.mapper;
 
 import com.soundie.comment.domain.Comment;
+import com.soundie.comment.domain.CommentWithAuthor;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -11,7 +12,7 @@ public interface CommentMapper {
 
     List<Comment> findComments();
 
-    List<Comment> findCommentsByPostId(@Param("postId") Long postId);
+    List<CommentWithAuthor> findCommentsWithAuthorByPostId(@Param("postId") Long postId);
 
     List<Comment> findCommentsByPostIdOrderByIdAsc(
             @Param("postId") Long postId,

--- a/module-core/src/main/java/com/soundie/comment/mapper/CommentMapper.java
+++ b/module-core/src/main/java/com/soundie/comment/mapper/CommentMapper.java
@@ -14,11 +14,11 @@ public interface CommentMapper {
 
     List<CommentWithAuthor> findCommentsWithAuthorByPostId(@Param("postId") Long postId);
 
-    List<Comment> findCommentsByPostIdOrderByIdAsc(
+    List<CommentWithAuthor> findCommentsWithAuthorByPostIdOrderByIdAsc(
             @Param("postId") Long postId,
             @Param("size") Integer size);
 
-    List<Comment> findCommentsByPostIdAndIdLessThanOrderByIdAsc(
+    List<CommentWithAuthor> findCommentsWithAuthorByPostIdAndIdLessThanOrderByIdAsc(
             @Param("postId") Long postId,
             @Param("id") Long commentId,
             @Param("size") Integer size);

--- a/module-core/src/main/java/com/soundie/comment/repository/CommentRepository.java
+++ b/module-core/src/main/java/com/soundie/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.soundie.comment.repository;
 
 import com.soundie.comment.domain.Comment;
+import com.soundie.comment.domain.CommentWithAuthor;
 
 import java.util.List;
 
@@ -8,7 +9,7 @@ public interface CommentRepository {
 
     List<Comment> findComments();
 
-    List<Comment> findCommentsByPostId(Long postId);
+    List<CommentWithAuthor> findCommentsWithAuthorByPostId(Long postId);
 
     List<Comment> findCommentsByPostIdOrderByIdAsc(Long postId, Integer size);
 

--- a/module-core/src/main/java/com/soundie/comment/repository/CommentRepository.java
+++ b/module-core/src/main/java/com/soundie/comment/repository/CommentRepository.java
@@ -11,9 +11,9 @@ public interface CommentRepository {
 
     List<CommentWithAuthor> findCommentsWithAuthorByPostId(Long postId);
 
-    List<Comment> findCommentsByPostIdOrderByIdAsc(Long postId, Integer size);
+    List<CommentWithAuthor> findCommentsWithAuthorByPostIdOrderByIdAsc(Long postId, Integer size);
 
-    List<Comment> findCommentsByPostIdAndIdLessThanOrderByIdAsc(Long postId, Long cursor, Integer size);
+    List<CommentWithAuthor> findCommentsWithAuthorByPostIdAndIdLessThanOrderByIdAsc(Long postId, Long cursor, Integer size);
 
     Number countCommentsByPostId(Long postId);
 

--- a/module-core/src/main/java/com/soundie/comment/repository/MyBatisCommentRepository.java
+++ b/module-core/src/main/java/com/soundie/comment/repository/MyBatisCommentRepository.java
@@ -1,6 +1,7 @@
 package com.soundie.comment.repository;
 
 import com.soundie.comment.domain.Comment;
+import com.soundie.comment.domain.CommentWithAuthor;
 import com.soundie.comment.mapper.CommentMapper;
 import com.soundie.global.common.util.CacheNames;
 import lombok.RequiredArgsConstructor;
@@ -24,11 +25,11 @@ public class MyBatisCommentRepository implements CommentRepository {
     }
 
     /*
-     * 음원 게시물 Id로, 댓글 목록 조회
+     * 음원 게시물 Id로, 댓글+작성자이름 목록 조회
      * */
     @Override
-    public List<Comment> findCommentsByPostId(Long postId) {
-        return commentMapper.findCommentsByPostId(postId);
+    public List<CommentWithAuthor> findCommentsWithAuthorByPostId(Long postId) {
+        return commentMapper.findCommentsWithAuthorByPostId(postId);
     }
 
     @Override

--- a/module-core/src/main/java/com/soundie/comment/repository/MyBatisCommentRepository.java
+++ b/module-core/src/main/java/com/soundie/comment/repository/MyBatisCommentRepository.java
@@ -33,13 +33,13 @@ public class MyBatisCommentRepository implements CommentRepository {
     }
 
     @Override
-    public List<Comment> findCommentsByPostIdOrderByIdAsc(Long postId, Integer size) {
-        return commentMapper.findCommentsByPostIdOrderByIdAsc(postId, size);
+    public List<CommentWithAuthor> findCommentsWithAuthorByPostIdOrderByIdAsc(Long postId, Integer size) {
+        return commentMapper.findCommentsWithAuthorByPostIdOrderByIdAsc(postId, size);
     }
 
     @Override
-    public List<Comment> findCommentsByPostIdAndIdLessThanOrderByIdAsc(Long postId, Long cursor, Integer size) {
-        return commentMapper.findCommentsByPostIdAndIdLessThanOrderByIdAsc(postId, cursor, size);
+    public List<CommentWithAuthor> findCommentsWithAuthorByPostIdAndIdLessThanOrderByIdAsc(Long postId, Long cursor, Integer size) {
+        return commentMapper.findCommentsWithAuthorByPostIdAndIdLessThanOrderByIdAsc(postId, cursor, size);
     }
 
     /*

--- a/module-core/src/main/java/com/soundie/comment/service/CommentService.java
+++ b/module-core/src/main/java/com/soundie/comment/service/CommentService.java
@@ -1,6 +1,7 @@
 package com.soundie.comment.service;
 
 import com.soundie.comment.domain.Comment;
+import com.soundie.comment.domain.CommentWithAuthor;
 import com.soundie.comment.dto.CommentIdElement;
 import com.soundie.comment.dto.GetCommentResDto;
 import com.soundie.comment.dto.PostCommentCreateReqDto;
@@ -42,10 +43,8 @@ public class CommentService {
         Post findPost = postRepository.findPostById(postId)
                 .orElseThrow(() -> new NotFoundException(ApplicationError.POST_NOT_FOUND));
 
-        List<Comment> comments = commentRepository.findCommentsByPostId(findPost.getId());
-        Map<Long, Member> findCommentsByMember = findCommentsByMember(comments);
-
-        return GetCommentResDto.of(comments, findCommentsByMember);
+        List<CommentWithAuthor> commentsWithAuthor = commentRepository.findCommentsWithAuthorByPostId(findPost.getId());
+        return GetCommentResDto.of(commentsWithAuthor);
     }
 
     public GetCommentCursorResDto readCommentListByCursor(Long postId, GetCommentCursorReqDto getCommentCursorReqDto) {

--- a/module-core/src/main/java/com/soundie/member/dto/AuthorElement.java
+++ b/module-core/src/main/java/com/soundie/member/dto/AuthorElement.java
@@ -1,6 +1,5 @@
 package com.soundie.member.dto;
 
-import com.soundie.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,13 +8,13 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuthorElement {
 
-    private final Long memberId;
+    private final Long id;
     private final String name;
 
-    public static AuthorElement of(Member member){
+    public static AuthorElement of(Long memberId, String memberName) {
         return new AuthorElement(
-                member.getId(),
-                member.getName()
+                memberId,
+                memberName
         );
     }
 }

--- a/module-core/src/main/java/com/soundie/post/domain/PostLike.java
+++ b/module-core/src/main/java/com/soundie/post/domain/PostLike.java
@@ -26,11 +26,4 @@ public class PostLike {
         this.memberId = memberId;
         this.postId = postId;
     }
-
-    /*
-     * MemoryRepository 저장 위함
-     * */
-    public void setId(Long id) {
-        this.id = id;
-    }
 }

--- a/module-core/src/main/resources/mybatis/mapper/CommentMapper.xml
+++ b/module-core/src/main/resources/mybatis/mapper/CommentMapper.xml
@@ -13,15 +13,16 @@
         from comment
     </select>
 
-    <!-- 음원 게시물 Id로, 댓글 목록 조회 -->
-    <select id="findCommentsByPostId" resultType="com.soundie.comment.domain.Comment">
+    <!-- 음원 게시물 Id로, 댓글+작성자이름 목록 조회 -->
+    <select id="findCommentsWithAuthorByPostId" resultType="com.soundie.comment.domain.CommentWithAuthor">
         select
-            id as "id",
-            member_id as "memberId",
-            post_id as "postId",
-            content as "content",
-            created_at as "createdAt"
-        from comment
+            c.id as "id",
+            c.member_id as "memberId",
+            m.name as "memberName",
+            c.post_id as "postId",
+            c.content as "content",
+            c.created_at as "createdAt"
+        from comment c join member m on (c.member_id = m.id)
         where post_id = #{postId}
     </select>
 

--- a/module-core/src/main/resources/mybatis/mapper/CommentMapper.xml
+++ b/module-core/src/main/resources/mybatis/mapper/CommentMapper.xml
@@ -26,32 +26,34 @@
         where post_id = #{postId}
     </select>
 
-    <select id="findCommentsByPostIdOrderByIdAsc"
-            resultType="com.soundie.comment.domain.Comment">
+    <select id="findCommentsWithAuthorByPostIdOrderByIdAsc"
+            resultType="com.soundie.comment.domain.CommentWithAuthor">
         select
-            id as "id",
-            member_id as "memberId",
-            post_id as "postId",
-            content as "content",
-            created_at as "createdAt"
-        from comment
-        where post_id = #{postId}
-        order by id asc
+            c.id as "id",
+            c.member_id as "memberId",
+            m.name as "memberName",
+            c.post_id as "postId",
+            c.content as "content",
+            c.created_at as "createdAt"
+        from comment c join member m on (c.member_id = m.id)
+        where c.post_id = #{postId}
+        order by c.id asc
         limit #{size}
     </select>
 
-    <select id="findCommentsByPostIdAndIdLessThanOrderByIdAsc"
-            resultType="com.soundie.comment.domain.Comment">
+    <select id="findCommentsWithAuthorByPostIdAndIdLessThanOrderByIdAsc"
+            resultType="com.soundie.comment.domain.CommentWithAuthor">
         select
-            id as "id",
-            member_id as "memberId",
-            post_id as "postId",
-            content as "content",
-            created_at as "createdAt"
-        from comment
-        where post_id = #{postId}
-            and id &gt; #{id}
-        order by id asc
+            c.id as "id",
+            c.member_id as "memberId",
+            m.name as "memberName",
+            c.post_id as "postId",
+            c.content as "content",
+            c.created_at as "createdAt"
+        from comment c join member m on (c.member_id = m.id)
+        where c.post_id = #{postId}
+            and c.id &gt; #{id}
+        order by c.id asc
         limit #{size}
     </select>
 

--- a/module-core/src/main/resources/mybatis/mapper/CommentMapper.xml
+++ b/module-core/src/main/resources/mybatis/mapper/CommentMapper.xml
@@ -23,7 +23,7 @@
             c.content as "content",
             c.created_at as "createdAt"
         from comment c join member m on (c.member_id = m.id)
-        where post_id = #{postId}
+        where c.post_id = #{postId}
     </select>
 
     <select id="findCommentsWithAuthorByPostIdOrderByIdAsc"

--- a/module-core/src/test/java/com/soundie/comment/service/CommentServiceTest.java
+++ b/module-core/src/test/java/com/soundie/comment/service/CommentServiceTest.java
@@ -2,6 +2,7 @@ package com.soundie.comment.service;
 
 
 import com.soundie.comment.domain.Comment;
+import com.soundie.comment.domain.CommentWithAuthor;
 import com.soundie.comment.dto.CommentIdElement;
 import com.soundie.comment.dto.GetCommentResDto;
 import com.soundie.comment.dto.PostCommentCreateReqDto;
@@ -21,9 +22,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,24 +54,18 @@ class CommentServiceTest {
         Post post = PostFixture.createFirstMemberHavingFirstPost();
         given(postRepository.findPostById(post.getId())).willReturn(Optional.of(post));
 
-        List<Comment> comments = List.of(
-                CommentFixture.createFirstComment(member1, post),
-                CommentFixture.createSecondComment(member2, post));
-        given(commentRepository.findCommentsByPostId(post.getId())).willReturn(comments);
-
-        Member findMember = new Member("findMember");
-        Map<Long, Member> linkedHashMap = new LinkedHashMap<>();
-        for (Comment comment : comments){
-                given(memberRepository.findMemberById(comment.getId())).willReturn(Optional.of(findMember));
-                linkedHashMap.put(comment.getId(), findMember);
-        }
+        List<CommentWithAuthor> commentsWithAuthor = List.of(
+                CommentFixture.createFirstCommentWithAuthor(member1, post),
+                CommentFixture.createSecondCommentWithAuthor(member2, post)
+        );
+        given(commentRepository.findCommentsWithAuthorByPostId(post.getId())).willReturn(commentsWithAuthor);
 
         // when
         GetCommentResDto response = commentService.readCommentList(post.getId());
 
         // then
         assertThat(response).usingRecursiveComparison()
-                .isEqualTo(GetCommentResDto.of(comments, linkedHashMap));
+                .isEqualTo(GetCommentResDto.of(commentsWithAuthor));
     }
 
     @DisplayName("유효하지 않은 postId가 주어졌다면, 음원 게시물의 댓글 목록 조회가 실패합니다.")

--- a/module-core/src/test/java/com/soundie/global/util/fixture/CommentFixture.java
+++ b/module-core/src/test/java/com/soundie/global/util/fixture/CommentFixture.java
@@ -1,8 +1,11 @@
 package com.soundie.global.util.fixture;
 
 import com.soundie.comment.domain.Comment;
+import com.soundie.comment.domain.CommentWithAuthor;
 import com.soundie.member.domain.Member;
 import com.soundie.post.domain.Post;
+
+import java.time.LocalDateTime;
 
 public class CommentFixture {
 
@@ -15,12 +18,25 @@ public class CommentFixture {
         );
     }
 
-    public static final Comment createSecondComment(Member member, Post post) {
-        return new Comment(
+    public static final CommentWithAuthor createFirstCommentWithAuthor(Member member, Post post) {
+        return new CommentWithAuthor(
+                1L,
+                member.getId(),
+                member.getName(),
+                post.getId(),
+                "댓글 내용1",
+                LocalDateTime.now()
+        );
+    }
+
+    public static final CommentWithAuthor createSecondCommentWithAuthor(Member member, Post post) {
+        return new CommentWithAuthor(
                 2L,
                 member.getId(),
+                member.getName(),
                 post.getId(),
-                "댓글 내용2"
+                "댓글 내용2",
+                LocalDateTime.now()
         );
     }
 }


### PR DESCRIPTION
## Description
- entity 클래스 → vo 클래스로 변경

## Todo
- 음원 게시물의 조회의 댓글 개수, 좋아요 개수는 분리 유지
- 음원 게시물의 댓글 조회를 한번에 회원 이름 조회로 변경