### PR TITLE
[#36] 음원 게시물 관련 캐시 기능 피드백 반영

### DIFF
--- a/module-core/src/main/java/com/soundie/global/common/util/CacheExpireTime.java
+++ b/module-core/src/main/java/com/soundie/global/common/util/CacheExpireTime.java
@@ -6,7 +6,6 @@ public class CacheExpireTime {
     public static final Long POST_CURSOR = 1L;
     public static final Long COMMENT = 1L;
     public static final Long COMMENT_COUNT = 1L;
-    public static final Long LIKE = 1L;
     public static final Long LIKE_COUNT = 1L;
     public static final Long MEMBER = 24L;
 }

--- a/module-core/src/main/java/com/soundie/global/common/util/CacheExpireTime.java
+++ b/module-core/src/main/java/com/soundie/global/common/util/CacheExpireTime.java
@@ -3,6 +3,7 @@ package com.soundie.global.common.util;
 public class CacheExpireTime {
 
     public static final Long POST = 1L;
+    public static final Long POST_CURSOR = 1L;
     public static final Long COMMENT = 1L;
     public static final Long COMMENT_COUNT = 1L;
     public static final Long LIKE = 1L;

--- a/module-core/src/main/java/com/soundie/global/common/util/CacheExpireTime.java
+++ b/module-core/src/main/java/com/soundie/global/common/util/CacheExpireTime.java
@@ -2,10 +2,10 @@ package com.soundie.global.common.util;
 
 public class CacheExpireTime {
 
-    public static final Long POST = 1L;
+    public static final Long POST = 5L;
     public static final Long POST_CURSOR = 1L;
-    public static final Long COMMENT = 1L;
+    public static final Long COMMENT = 5L;
     public static final Long COMMENT_COUNT = 1L;
     public static final Long LIKE_COUNT = 1L;
-    public static final Long MEMBER = 24L;
+    public static final Long MEMBER = 5L;
 }

--- a/module-core/src/main/java/com/soundie/global/common/util/CacheExpireTime.java
+++ b/module-core/src/main/java/com/soundie/global/common/util/CacheExpireTime.java
@@ -4,7 +4,7 @@ public class CacheExpireTime {
 
     public static final Long POST = 5L;
     public static final Long POST_CURSOR = 1L;
-    public static final Long COMMENT = 5L;
+    public static final Long COMMENT_CURSOR = 1L;
     public static final Long COMMENT_COUNT = 1L;
     public static final Long LIKE_COUNT = 1L;
     public static final Long MEMBER = 5L;

--- a/module-core/src/main/java/com/soundie/global/common/util/CacheNames.java
+++ b/module-core/src/main/java/com/soundie/global/common/util/CacheNames.java
@@ -3,6 +3,7 @@ package com.soundie.global.common.util;
 public class CacheNames {
 
     public static final String POST = "post";
+    public static final String POST_CURSOR = "post_cursor";
     public static final String COMMENT = "comment";
     public static final String COMMENT_COUNT = "comment_count";
     public static final String LIKE = "like";

--- a/module-core/src/main/java/com/soundie/global/common/util/CacheNames.java
+++ b/module-core/src/main/java/com/soundie/global/common/util/CacheNames.java
@@ -4,7 +4,7 @@ public class CacheNames {
 
     public static final String POST = "post";
     public static final String POST_CURSOR = "post_cursor";
-    public static final String COMMENT = "comment";
+    public static final String COMMENT_CURSOR = "comment_cursor";
     public static final String COMMENT_COUNT = "comment_count";
     public static final String LIKE_COUNT = "like_count";
     public static final String MEMBER = "member";

--- a/module-core/src/main/java/com/soundie/global/common/util/CacheNames.java
+++ b/module-core/src/main/java/com/soundie/global/common/util/CacheNames.java
@@ -6,7 +6,6 @@ public class CacheNames {
     public static final String POST_CURSOR = "post_cursor";
     public static final String COMMENT = "comment";
     public static final String COMMENT_COUNT = "comment_count";
-    public static final String LIKE = "like";
     public static final String LIKE_COUNT = "like_count";
     public static final String MEMBER = "member";
 }

--- a/module-core/src/main/java/com/soundie/global/config/CacheConfig.java
+++ b/module-core/src/main/java/com/soundie/global/config/CacheConfig.java
@@ -49,11 +49,11 @@ public class CacheConfig {
                         RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())
                 );
         Map<String, RedisCacheConfiguration> redisCacheConfigMap = new HashMap<>();
-        redisCacheConfigMap.put(CacheNames.POST, defaultCacheConfig.entryTtl(Duration.ofHours(CacheExpireTime.POST)));
+        redisCacheConfigMap.put(CacheNames.POST, defaultCacheConfig.entryTtl(Duration.ofSeconds(CacheExpireTime.POST)));
         redisCacheConfigMap.put(CacheNames.COMMENT, defaultCacheConfig.entryTtl(Duration.ofHours(CacheExpireTime.COMMENT)));
         redisCacheConfigMap.put(CacheNames.COMMENT_COUNT, defaultCacheConfig.entryTtl(Duration.ofHours(CacheExpireTime.COMMENT_COUNT)));
         redisCacheConfigMap.put(CacheNames.LIKE_COUNT, defaultCacheConfig.entryTtl(Duration.ofHours(CacheExpireTime.LIKE_COUNT)));
-        redisCacheConfigMap.put(CacheNames.MEMBER, defaultCacheConfig.entryTtl(Duration.ofHours(CacheExpireTime.MEMBER)));
+        redisCacheConfigMap.put(CacheNames.MEMBER, defaultCacheConfig.entryTtl(Duration.ofSeconds(CacheExpireTime.MEMBER)));
 
         return RedisCacheManager.builder(redisCacheConnectionFactory())
                 .withInitialCacheConfigurations(redisCacheConfigMap)

--- a/module-core/src/main/java/com/soundie/global/config/CacheConfig.java
+++ b/module-core/src/main/java/com/soundie/global/config/CacheConfig.java
@@ -50,7 +50,6 @@ public class CacheConfig {
                 );
         Map<String, RedisCacheConfiguration> redisCacheConfigMap = new HashMap<>();
         redisCacheConfigMap.put(CacheNames.POST, defaultCacheConfig.entryTtl(Duration.ofSeconds(CacheExpireTime.POST)));
-        redisCacheConfigMap.put(CacheNames.COMMENT, defaultCacheConfig.entryTtl(Duration.ofHours(CacheExpireTime.COMMENT)));
         redisCacheConfigMap.put(CacheNames.COMMENT_COUNT, defaultCacheConfig.entryTtl(Duration.ofHours(CacheExpireTime.COMMENT_COUNT)));
         redisCacheConfigMap.put(CacheNames.LIKE_COUNT, defaultCacheConfig.entryTtl(Duration.ofHours(CacheExpireTime.LIKE_COUNT)));
         redisCacheConfigMap.put(CacheNames.MEMBER, defaultCacheConfig.entryTtl(Duration.ofSeconds(CacheExpireTime.MEMBER)));

--- a/module-core/src/main/java/com/soundie/global/config/CacheConfig.java
+++ b/module-core/src/main/java/com/soundie/global/config/CacheConfig.java
@@ -52,7 +52,6 @@ public class CacheConfig {
         redisCacheConfigMap.put(CacheNames.POST, defaultCacheConfig.entryTtl(Duration.ofHours(CacheExpireTime.POST)));
         redisCacheConfigMap.put(CacheNames.COMMENT, defaultCacheConfig.entryTtl(Duration.ofHours(CacheExpireTime.COMMENT)));
         redisCacheConfigMap.put(CacheNames.COMMENT_COUNT, defaultCacheConfig.entryTtl(Duration.ofHours(CacheExpireTime.COMMENT_COUNT)));
-        redisCacheConfigMap.put(CacheNames.LIKE, defaultCacheConfig.entryTtl(Duration.ofHours(CacheExpireTime.LIKE)));
         redisCacheConfigMap.put(CacheNames.LIKE_COUNT, defaultCacheConfig.entryTtl(Duration.ofHours(CacheExpireTime.LIKE_COUNT)));
         redisCacheConfigMap.put(CacheNames.MEMBER, defaultCacheConfig.entryTtl(Duration.ofHours(CacheExpireTime.MEMBER)));
 

--- a/module-core/src/main/java/com/soundie/post/repository/MyBatisPostLikeRepository.java
+++ b/module-core/src/main/java/com/soundie/post/repository/MyBatisPostLikeRepository.java
@@ -4,7 +4,6 @@ import com.soundie.global.common.util.CacheNames;
 import com.soundie.post.domain.PostLike;
 import com.soundie.post.mapper.PostLikeMapper;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 
@@ -29,10 +28,6 @@ public class MyBatisPostLikeRepository implements PostLikeRepository{
      * 회원 Id + 음원 게시물 Id로, 좋아요 조회
      * */
     @Override
-    @Cacheable(cacheNames = CacheNames.LIKE,
-            key = "'memberId_' + #memberId + ':postId_' + #postId",
-            unless = "#result == null"
-    )
     public Optional<PostLike> findPostLikeByMemberIdAndPostId(Long memberId, Long postId) {
         return postLikeMapper.findPostLikeByMemberIdAndPostId(memberId, postId);
     }
@@ -50,7 +45,6 @@ public class MyBatisPostLikeRepository implements PostLikeRepository{
      * 좋아요 저장
      * */
     @Override
-    @Cacheable(cacheNames = CacheNames.LIKE, key = "'memberId_' + #postLike.memberId + ':postId_' + #postLike.postId")
     public PostLike save(PostLike postLike) {
         postLikeMapper.save(postLike);
         return postLike;
@@ -60,7 +54,6 @@ public class MyBatisPostLikeRepository implements PostLikeRepository{
      * 좋아요 삭제
      * */
     @Override
-    @CacheEvict(cacheNames = CacheNames.LIKE, key = "'memberId_' + #postLike.memberId + ':postId_' + #postLike.postId")
     public void delete(PostLike postLike) {
         postLikeMapper.delete(postLike);
     }

--- a/module-core/src/main/java/com/soundie/post/service/PostService.java
+++ b/module-core/src/main/java/com/soundie/post/service/PostService.java
@@ -46,8 +46,15 @@ public class PostService {
         Long cursor = getPostCursorReqDto.getCursor();
         Integer size = getPostCursorReqDto.getSize();
 
+        // 첫 페이지 x, db 조회
+        if (!cursor.equals(PaginationUtil.START_CURSOR)) {
+            List<Post> findPosts = findPostsByCursorCheckExistsCursor(cursor, size);
+            List<PostWithCount> findPostsWithCount = findPostsWithCount(findPosts);
+            return GetPostCursorResDto.of(findPostsWithCount, size);
+        }
+
         // 커스텀 캐시 존재 x, 캐시 저장
-        if (cursor.equals(PaginationUtil.START_CURSOR) && Boolean.FALSE.equals(redisCacheTemplate.hasKey(CacheNames.POST_CURSOR))){
+        if (Boolean.FALSE.equals(redisCacheTemplate.hasKey(CacheNames.POST_CURSOR))){
             List<Post> findPosts = findPostsByCursorCheckExistsCursor(cursor, size);
             List<PostWithCount> findPostsWithCount = findPostsWithCount(findPosts);
 

--- a/module-core/src/main/resources/mybatis/mapper/CommentMapper.xml
+++ b/module-core/src/main/resources/mybatis/mapper/CommentMapper.xml
@@ -65,7 +65,7 @@
     </select>
 
     <!-- 댓글 저장 -->
-    <insert id="save" useGeneratedKeys="true" keyProperty="id">
+    <insert id="save" useGeneratedKeys="true" keyProperty="id,createdAt">
         insert into comment (member_id, post_id, content)
         values (#{comment.memberId},
                 #{comment.postId},


### PR DESCRIPTION
## Description
- 캐시  적용
  - 회원 조회 기능
  - 음원 게시물 목록 조회(Cursor Pagination) 기능
  - 음원 게시물 상세 조회 기능 
  - 음원 게시물 등록 기능
  - 음원 게시물 좋아요 기능
  - 음원 게시물의 댓글 목록 조회(Cursor Pagination) 기능
  - 음원 게시물의 댓글 등록 기능
  
## Todo
- 회원 캐시
  - 음원 게시물 관련 조회 시 필요하므로, Cache 적용 
   - **캐시 적용 시간 짧게 수정**
- 음원 게시물 목록(Cursor Pagiantion) 캐시
  - 쓰기 작업을 위해 Deque 형식으로 저장
  - 음원 게시물은 Cursor Pagination 으로 조회 시,
     최근 등록 시간으로 페이징하기 때문에, Cache 초기화 필요
  -  **Cursor 마다 캐시 아닌, 하나의 Custom 캐시로 수정**
- 음원 게시물 캐시
  - 조회 시 필요하므로, Cache 적용
   - **캐시 적용 시간 짧게 수정**
- 음원 게시물 댓글 개수 캐시
  - 음원 게시물 조회 시 필요하므로, Cache 적용
- 음원 게시물 좋아요 개수 캐시
  - 음원 게시물 조회 시 필요하므로, Cache 적용
- 음원 게시물 좋아요 캐시
  - 음원 게시물 조회 시 필요하므로, Cache 적용
  - **캐시 적용하지 않음으로 수정**
- 음원 게시물의 댓글 목록(Cursor Pagiantion) 캐시
  - 쓰기 작업을 위해 List 형식으로 저장
  - 음원 게시물의 댓글은 Cursor Pagination 으로 조회 시,
     과거 등록 시간으로 페이징하기 때문에, Cache 초기화 필요
  -  **Cursor 마다 캐시 아닌, 하나의 Custom 캐시로 수정**